### PR TITLE
Avoid overinitializing multiselect

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -37,7 +37,7 @@ export default class UiBibzForm {
   }
 
   setMultiSelect() {
-    $('.multi-select-field', this.node).each(function() {
+    $('select.multi-select-field', this.node).each(function() {
       var classes, data
       data = $(this).data()
       classes = $(this)[0].classList.value


### PR DESCRIPTION
When using Turbo Drive in case some page elements are kept from a page
load to another, the multiselects are kept initialized. In this case,
for each multiselect field, there is a select.multi-select-field DOM
object and a button.multi-select-field that is generated by the
Multiselect widget.

Avoid matching the button.multi-select-field in those cases to avoid
initializing gazillions of multi-select-fields (multiplying by 2 each
time the number of fields on the page)